### PR TITLE
Fix the generic format.

### DIFF
--- a/src/reflection.cr
+++ b/src/reflection.cr
@@ -39,7 +39,7 @@ module Cruml::Reflection
           method_info = Cruml::Entities::MethodInfo.new(
             {{ method.visibility }},
             {{ method.name.stringify }},
-            {{ method.return_type.stringify.empty? ? "Nil" : method.return_type.stringify.gsub(/[()]/, "~") }}
+            {{ method.return_type.stringify.empty? ? "Nil" : method.return_type.stringify }}
           )
 
           {% for arg in method.args %}

--- a/src/renders/diagram_render.cr
+++ b/src/renders/diagram_render.cr
@@ -68,7 +68,13 @@ class Cruml::Renders::DiagramRender
                         when :private   then '-'
                         else                 '+'
                         end
-        @code += "    #{literal_scope}#{method.name}(#{method.generate_args}) #{method.return_type}\n"
+        @code += "    #{literal_scope}#{method.name}(#{method.generate_args}) "
+
+        if method.return_type =~ /\(.*\)/
+          @code += " : "
+        end
+
+        @code += "#{method.return_type}\n"
       end
     end
 


### PR DESCRIPTION
## Description

Due to #2, the generic is not formated correctly when adding more types than 2. The solution is to replace `<` and `>` by parantheses.

![image](https://github.com/user-attachments/assets/1418914d-5eeb-46ce-a0ce-fd3505610c7d)

## Changelog
- Fix the generic format

## Issue reference
Generic return value is not formated correctly: #2