### PR TITLE
Add a config to format the HTML files (dev only).

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,11 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
+
+[*.html]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/src/renders/diagram_render.cr
+++ b/src/renders/diagram_render.cr
@@ -31,11 +31,12 @@ class Cruml::Renders::DiagramRender
         end
       end
 
-      @code << "namespace " << namespace << " {\n"        # begin namespace
+      # Namespace block
+      @code << "namespace " << namespace << " {\n"
       classes.each do |class_info|
         add_class(class_info)
       end
-      @code << "}\n"                                      # end namespace
+      @code << "}\n"
     end
     set_diagram_colors
   end


### PR DESCRIPTION
## Description

HTML configuration is added to the `.editorconfig` file to format these files with an indent of 4 spaces. The HTML file format only takes effect in the dev environment.

## Changelog

- Add a config to format the HTML files (dev only).