### PR TITLE
Refactor the code located in the `src/render` directory.

### DIFF
--- a/src/class_list.cr
+++ b/src/class_list.cr
@@ -21,7 +21,10 @@ class Cruml::ClassList
 
   # Groups the classes by their namespaces.
   def self.group_by_namespaces
-    @@classes.group_by(&.name.split(".").first)
+    @@classes.group_by do |klass|
+      namespace = klass.name.split("::")
+      namespace.size > 2 ? namespace[0..-2].join("::") : namespace[0]
+    end
   end
 
   def self.verify_instance_var_duplication : Nil

--- a/src/console.cr
+++ b/src/console.cr
@@ -1,10 +1,10 @@
 require "option_parser"
 require "./transformer"
 require "./renders/diagram_render"
+require "./renders/config"
 
 files = [] of String
 verbose = false
-dark_mode = false
 
 OptionParser.parse do |parser|
   parser.banner = "Usage : cruml [subcommand] [arguments] -- [options]"
@@ -13,7 +13,14 @@ OptionParser.parse do |parser|
     parser.banner = "Usage : cruml generate [arguments] -- [options]"
 
     parser.on "--verbose", "Enable verbose" { verbose = true }
-    parser.on "--dark-mode", "Set to dark mode" { dark_mode = true }
+
+    parser.on "--dark-mode", "Set to dark mode" do
+      Cruml::Renders::Config.theme = :dark
+    end
+
+    parser.on "--no-color", "Disable color output" do
+      Cruml::Renders::Config.no_color = true
+    end
 
     parser.on "--path=PATH", "Path to specify" do |path|
       files << path if File.file?(path) && path.ends_with?(".cr")
@@ -32,14 +39,14 @@ OptionParser.parse do |parser|
   end
 
   parser.invalid_option do |flag|
-    STDERR.puts "\e[31mERROR: #{flag} is not a valid option.\e[0m"
+    STDERR.puts "ERROR: #{flag} is not a valid option.".colorize(:red)
     STDERR.puts parser
     exit 1
   end
 end
 
 if files.size == 0
-  puts "No crystal files are present in the path, please retry."
+  puts "No crystal files are present in the path, please retry.".colorize(:red)
   exit 1
 end
 
@@ -51,4 +58,6 @@ end
 
 Cruml::ClassList.verify_instance_var_duplication
 
-Cruml::Renders::DiagramRender.new("out/diagram.html").save
+diagram = Cruml::Renders::DiagramRender.new("out/diagram.html")
+diagram.generate
+diagram.save

--- a/src/renders/config.cr
+++ b/src/renders/config.cr
@@ -1,0 +1,46 @@
+# Stores the diagram configuration.
+class Cruml::Renders::Config
+  # The theme of the diagram (`:light` or `:dark`).
+  class_property theme : Symbol = :light
+
+  # Whether to disable colors in the diagram.
+  class_property? no_color : Bool = false
+
+  # Gets the color for classes.
+  def self.class_color : String
+    @@theme == :light ? "#baa7e5" : "#2e1065"
+  end
+
+  # Gets the color for abstract classes.
+  def self.abstract_color : String
+    @@theme == :light ? "#a7e5a7" : "#365314"
+  end
+
+  # Gets the color for modules.
+  def self.module_color : String
+    @@theme == :light ? "#5ab3f4" : "#0041cc"
+  end
+
+  # Gets the theme color.
+  def self.theme_color : String
+    @@theme == :light ? "#dedede" : "#212121"
+  end
+
+  # Gets the text color.
+  def self.text_color : String
+    @@theme == :light ? "#000000" : "#ffffff"
+  end
+
+  # Generates the class definitions for the diagram.
+  def self.class_def_colors : String
+    String.build do |io|
+      [{:default, self.class_color}, {:abstract, self.abstract_color}, {:module, self.module_color}].each do |type, color|
+        io << "classDef " << type << " fill:"
+        io << (@@no_color == true ? self.theme_color : color)
+        io << ",color:" << self.text_color
+        io << ",stroke:" << (@@theme == :dark ? "#fff" : "#000")
+        io << "\n"
+      end
+    end
+  end
+end

--- a/src/renders/diagram.ecr
+++ b/src/renders/diagram.ecr
@@ -20,17 +20,34 @@
             overflow: hidden;
         }
 
+        .loading-view {
+            width: 100%;
+            height: 100vh;
+            z-index: 1;
+            position: absolute;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
         .mermaid {
             width: 100%;
             height: 100%;
             display: flex;
             justify-content: center;
             align-items: center;
+            visibility: hidden;
+            cursor: grab;
+        }
+
+        .mermaid:active {
+            cursor: grabbing;
         }
     </style>
 </head>
 
 <body>
+    <div class="loading-view">Loading...</div>
     <!--
         Mermaid code will be set here. After that, a class diagram will be displayed on the web browser.
     -->
@@ -42,6 +59,9 @@
          * Load the UML class diagram once the page is loaded.
          */
         window.addEventListener("DOMContentLoaded", () => {
+            document.querySelector(".mermaid").style.visibility = "visible";
+            document.querySelector(".loading-view").style.visibility = "hidden";
+
             mermaid.initialize({
                 startOnLoad: true,
                 maxTextSize: Infinity,

--- a/src/renders/diagram.ecr
+++ b/src/renders/diagram.ecr
@@ -16,7 +16,7 @@
             width: 100vw;
             height: 100vh;
             margin: 0 auto;
-            background-color: #212121;
+            background-color: <%= Cruml::Renders::Config.theme_color %>;
             overflow: hidden;
         }
 
@@ -65,7 +65,7 @@
             mermaid.initialize({
                 startOnLoad: true,
                 maxTextSize: Infinity,
-                theme: "dark"
+                theme: <%= Cruml::Renders::Config.theme.to_s.dump %>
             });
             panzoom(document.querySelector(".mermaid"), {
                 zoomSpeed: 0.2

--- a/src/renders/diagram_render.cr
+++ b/src/renders/diagram_render.cr
@@ -6,68 +6,18 @@ require "./uml"
 class Cruml::Renders::DiagramRender
   include Cruml::Renders::UML
 
-  @code = String::Builder.new("classDiagram\n")
+  getter code = String::Builder.new("classDiagram\n")
 
-  def initialize(@path_dir : String)
-    Cruml::ModuleList.modules.each do |mod|
-      @code << "namespace #{mod.name.gsub("::", '.').split('.').first} {\n"
-      @code << "class #{mod.name.gsub("::", '.')}:::module {\n"
-      @code << "&lt;&lt;module&gt;&gt;\n"
-      add_instance_vars(mod.instance_vars)
-      add_methods(mod.methods)
-      @code << "}\n"
-      @code << "}\n"
-    end
+  def initialize(@path_dir : String); end
 
-    Cruml::ClassList.group_by_namespaces.each do |klass_group|
-      namespace, classes = klass_group[0], klass_group[1]
-
-      # Add a relationship before creating a namespace.
-      classes.each do |klass|
-        add_parent_class(klass.parent_classes)
-        klass.included_modules.each do |included_module|
-          @code << namespace + '.' if namespace
-          @code << "#{included_module} <|-- #{klass.name}\n"
-        end
-      end
-
-      @code << "namespace " << namespace << " {\n"        # begin namespace
-      classes.each do |class_info|
-        add_class(class_info)
-      end
-      @code << "}\n"                                      # end namespace
-    end
+  # Generates the class diagram.
+  def generate : Nil
+    generate_module_diagrams
+    generate_class_diagrams
     set_diagram_colors
   end
 
-  # Creates a class with a whole set of instance variables and methods.
-  # See https://mermaid.js.org/syntax/classDiagram.html#class for more info.
-  private def add_class(class_info : Cruml::Entities::ClassInfo) : Nil
-    short_class_name = class_info.name.split("::")[-1]
-
-    case class_info.type # begin class
-    when :abstract
-      @code << "  class #{short_class_name}:::abstract {\n"
-      @code << "    &lt;&lt;abstract&gt;&gt;\n"
-    when :class
-      @code << "  class #{short_class_name} {\n"
-    end
-
-    add_instance_vars(class_info.instance_vars)
-    add_methods(class_info.methods)
-
-    @code << "  }\n" # end class
-  end
-
-  # Define the style properties for the class diagram.
-  # See https://mermaid.js.org/syntax/classDiagram.html#default-class for more info.
-  private def set_diagram_colors : Nil
-    @code << "classDef default fill:#2e1065,color:white\n"
-    @code << "classDef abstract fill:#365314,color:white\n"
-    @code << "classDef module fill:#0041cc,color:white"
-  end
-
-  # Save the class diagram as a HTML file.
+  # Saves the class diagram as an HTML file.
   def save : Nil
     output = ECR.render("src/renders/diagram.ecr")
     File.write(@path_dir, output)

--- a/src/renders/uml.cr
+++ b/src/renders/uml.cr
@@ -9,7 +9,42 @@ module Cruml::Renders::UML
     end
   end
 
-  # Add the instance vars into class.
+  # Generates module diagrams.
+  private def generate_module_diagrams
+    Cruml::ModuleList.modules.each do |mod|
+      @code << "namespace #{mod.name.gsub("::", '.').split('.').first} {\n"
+      @code << "class #{mod.name.gsub("::", '.')}:::module {\n"
+      @code << "&lt;&lt;module&gt;&gt;\n"
+      add_instance_vars(mod.instance_vars)
+      add_methods(mod.methods)
+      @code << "}\n"
+      @code << "}\n"
+    end
+  end
+
+  # Generates class diagrams.
+  private def generate_class_diagrams
+    Cruml::ClassList.group_by_namespaces.each do |klass_group|
+      namespace, classes = klass_group[0], klass_group[1]
+
+      # Add a relationship before creating a namespace.
+      classes.each do |klass|
+        add_parent_class(klass.parent_classes)
+        klass.included_modules.each do |included_module|
+          @code << namespace.gsub("::", '.') + '.' if namespace
+          @code << "#{included_module.gsub("::", '.')} <|-- #{klass.name.gsub("::", '.')}\n"
+        end
+      end
+
+      @code << "namespace " << namespace.gsub("::", '.') << " {\n"
+      classes.each do |class_info|
+        add_class(class_info)
+      end
+      @code << "}\n"
+    end
+  end
+
+  # Adds instance variables to the class.
   private def add_instance_vars(instance_vars : Array(Tuple(String, String))) : Nil
     instance_vars.each do |ivar|
       name, type = ivar[-2], ivar[-1]
@@ -17,6 +52,25 @@ module Cruml::Renders::UML
     end
   end
 
+  # Creates a class with a complete set of instance variables and methods.
+  private def add_class(class_info : Cruml::Entities::ClassInfo) : Nil
+    short_class_name = class_info.name.gsub("::", '.')
+
+    case class_info.type # begin class
+    when :abstract
+      @code << "  class #{short_class_name}:::abstract {\n"
+      @code << "    &lt;&lt;abstract&gt;&gt;\n"
+    when :class
+      @code << "  class #{short_class_name} {\n"
+    end
+
+    add_instance_vars(class_info.instance_vars)
+    add_methods(class_info.methods)
+
+    @code << "  }\n" # end class
+  end
+
+  # Adds methods to the class.
   private def add_methods(methods : Array(Cruml::Entities::MethodInfo)) : Nil
     methods.each do |method|
       visibility = method_visibility(method.visibility)
@@ -27,7 +81,7 @@ module Cruml::Renders::UML
     end
   end
 
-  # Creates a link between the parent and child classes.
+  # Creates a link between parent and child classes.
   # If the parent class type is abstract, the arrow would look like : <|..
   # If the parent class type is normal, the arrow would look like : <|--
   # See https://mermaid.js.org/syntax/classDiagram.html#defining-relationship for more info.
@@ -35,10 +89,16 @@ module Cruml::Renders::UML
     inherit_classes.each do |class_name, subclass_name, class_type|
       case class_type
       when :abstract
-        @code << "#{class_name.split("::")[-1]} <|.. #{subclass_name.split("::")[-1]}\n"
+        @code << "#{class_name.gsub("::", '.')} <|.. #{subclass_name.gsub("::", '.')}\n"
       when :class
-        @code << "#{class_name.split("::")[-1]} <|-- #{subclass_name.split("::")[-1]}\n"
+        @code << "#{class_name.gsub("::", '.')} <|-- #{subclass_name.gsub("::", '.')}\n"
       end
     end
+  end
+
+  # Defines the style properties for the class diagram.
+  # See https://mermaid.js.org/syntax/classDiagram.html#default-class for more info.
+  private def set_diagram_colors : Nil
+    @code << Cruml::Renders::Config.class_def_colors
   end
 end

--- a/src/transformer.cr
+++ b/src/transformer.cr
@@ -19,7 +19,7 @@ class Cruml::Transformer < Crystal::Transformer
   end
 
   def transform(node : Crystal::ClassDef) : Crystal::ASTNode
-    @current_class_name = node.name.to_s.gsub("::", ".")
+    @current_class_name = node.name.to_s
     @current_module_name = ""
 
     # If a class def contains the generic
@@ -33,7 +33,7 @@ class Cruml::Transformer < Crystal::Transformer
 
     # Replace the "::" by "." for namespaces.
     if node.superclass
-      class_info.add_parent_class(node.superclass.to_s.gsub("::", "."))
+      class_info.add_parent_class(node.superclass.to_s)
     end
 
     Cruml::ClassList.add(class_info)
@@ -41,7 +41,7 @@ class Cruml::Transformer < Crystal::Transformer
     # Check if there's an "include" keyword followed by a module
     node.body.to_s.each_line do |line|
       if match = line.match(/^include (\w+(?:::\w+)*)$/)
-        included_module = match[1].gsub("::", ".")
+        included_module = match[1]
         Cruml::ClassList.find_by_name!(@current_class_name).add_included_module(included_module)
       end
     end


### PR DESCRIPTION
## Description

This PR consists to organize the code for consistency.

## Changelog

- Refactor the code in the `Cruml::Renders` module.
- Add the loading page.
- Fix the `#group_by_namespaces` static method to calculate the namespace depth level.
- Added feature to configure the theme.