### PR TITLE
Remove the crystalline config

### DIFF
--- a/.crystalline_main.cr
+++ b/.crystalline_main.cr
@@ -1,3 +1,0 @@
-# .crystalline_main.cr
-require "./src/cruml.cr"
-require "./spec/**"

--- a/shard.yml
+++ b/shard.yml
@@ -11,9 +11,6 @@ targets:
   cruml:
     main: src/cruml.cr
 
-crystalline:
-  main: .crystalline_main.cr
-
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba


### PR DESCRIPTION
## Description

This PR consists of deleting the Crystalline config file because Crystalline is automatically able to guess the entry point of the file, which is `src/cruml.cr`.

## Changelog

- Remove the crystalline config.