### PR TITLE
Add the `--output-dir` flag

### DIFF
--- a/src/console.cr
+++ b/src/console.cr
@@ -28,7 +28,7 @@ OptionParser.parse do |parser|
       files |= Dir.glob("#{path}/**/*.cr") if File.directory?(path)
     end
 
-    parser.on "--output-dir=DIR", "Path to specify" { |dir| output = dir }
+    parser.on "--output-dir=DIR", "Path to specify" { |dir| output_dir = dir }
   end
 
   parser.on "-v", "--version", "Show the version" do

--- a/src/console.cr
+++ b/src/console.cr
@@ -5,6 +5,7 @@ require "./renders/config"
 
 files = [] of String
 verbose = false
+output_dir = "out/"
 
 OptionParser.parse do |parser|
   parser.banner = "Usage : cruml [subcommand] [arguments] -- [options]"
@@ -26,6 +27,8 @@ OptionParser.parse do |parser|
       files << path if File.file?(path) && path.ends_with?(".cr")
       files |= Dir.glob("#{path}/**/*.cr") if File.directory?(path)
     end
+
+    parser.on "--output-dir=DIR", "Path to specify" { |dir| output = dir }
   end
 
   parser.on "-v", "--version", "Show the version" do
@@ -58,6 +61,6 @@ end
 
 Cruml::ClassList.verify_instance_var_duplication
 
-diagram = Cruml::Renders::DiagramRender.new("out/diagram.html")
+diagram = Cruml::Renders::DiagramRender.new("#{output_dir}/diagram.html")
 diagram.generate
 diagram.save

--- a/src/renders/diagram_render.cr
+++ b/src/renders/diagram_render.cr
@@ -1,4 +1,5 @@
 require "ecr"
+require "file_utils"
 require "./uml"
 
 # Consists of generating a class diagram.
@@ -20,6 +21,11 @@ class Cruml::Renders::DiagramRender
   # Saves the class diagram as an HTML file.
   def save : Nil
     output = ECR.render("src/renders/diagram.ecr")
+    dir = File.dirname(@path_dir)
+    FileUtils.mkdir_p(dir) unless Dir.exists?(dir)
     File.write(@path_dir, output)
+  rescue error : File::AccessDeniedError
+    puts "An error is occured when saving the diagram into #{@path_dir}. Please retry.".colorize(:red)
+    puts ("Reason of this error : " + error.to_s).colorize(:red)
   end
 end


### PR DESCRIPTION
## Description

This PR adds a flag named `--output-dir`. The latter consists in saving the class diagram in a specific path. If this flag is not specified, the default path is `out/` from the current path.

## Changelog
- Add the `--output-dir` flag