### PR TITLE
Fix namespace prefix

### DIFF
--- a/src/renders/uml.cr
+++ b/src/renders/uml.cr
@@ -20,7 +20,7 @@ module Cruml::Renders::UML
       namespace = mod.name.gsub("::", '-').split('-')
       namespace.pop if namespace.size > 1
 
-      @code << INDENT * 2 << "namespace " << namespace.join('-') << " {\n"
+      @code << INDENT * 2 << "namespace -" << namespace.join('-') << " {\n"
       case mod.type
       when :normal
         @code << INDENT * 3 << "class `" << mod.name << "`:::module {\n"


### PR DESCRIPTION
## Description

This change adds a `-` to distinguish the namespace from the class name.

## Changelog

- Fix namespace prefix