### PR TITLE
Set the ameba version to `~> 1.6.0`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -14,6 +14,7 @@ targets:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    version: ~> 1.6.0
 
 scripts:
   postinstall: shards build cruml


### PR DESCRIPTION
## Description

The `crystal-ameba/ameba` version is set to `~> 1.6.0`. For the moment, only patch updates will be applied. If necessary, this version can be changed in the future.

## Changelog

- Set the ameba version to `~> 1.6.0`