### PR TITLE
Setup the `--verbose` flag

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,10 @@ targets:
   cruml:
     main: src/cruml.cr
 
+dependencies:
+  tallboy:
+    github: epoch/tallboy
+
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "./../src/entities/**"
+require "./../src/renders/config"
 
 def parse_module_helper : Nil
   code = <<-CRYSTAL

--- a/src/entities/class_info.cr
+++ b/src/entities/class_info.cr
@@ -13,6 +13,10 @@ class Cruml::Entities::ClassInfo
   def add_instance_var(name : String, type : String) : Nil
     @instance_vars.reject! { |ivar| ivar[0] == name }
     @instance_vars << {name, type}
+
+    if Cruml::Renders::Config.verbose? == true
+      puts "VERBOSE : #{@name.colorize(:magenta)} instance var added to #{@name.colorize(:magenta)} class."
+    end
   end
 
   # Adds a parent class into an array of parent classes.
@@ -21,11 +25,19 @@ class Cruml::Entities::ClassInfo
     if found_class
       @parent_classes << {parent_class_name, @name, found_class.type}
     end
+
+    if Cruml::Renders::Config.verbose? == true
+      puts "VERBOSE : #{@name.colorize(:magenta)} child class linked to #{parent_class_name.colorize(:magenta)} parent class."
+    end
   end
 
   # Adds a module name to the list of included modules.
   def add_included_module(module_name : String) : Nil
     @included_modules << module_name
+
+    if Cruml::Renders::Config.verbose? == true
+      puts "VERBOSE : #{module_name.colorize(:magenta)} module to #{@name.colorize(:magenta)} class."
+    end
   end
 
   # Adds a method into an array of methods.
@@ -34,6 +46,10 @@ class Cruml::Entities::ClassInfo
       @methods.unshift(method)
     else
       @methods << method
+    end
+
+    if Cruml::Renders::Config.verbose? == true
+      puts "VERBOSE : #{method.name.colorize(:magenta)}() method to #{@name.colorize(:magenta)} class."
     end
   end
 end

--- a/src/entities/method_info.cr
+++ b/src/entities/method_info.cr
@@ -10,6 +10,10 @@ class Cruml::Entities::MethodInfo
   # Add an argument into the args list.
   def add_arg(arg : Cruml::Entities::ArgInfo)
     @args << arg
+
+    if Cruml::Renders::Config.verbose? == true
+      puts "VERBOSE : #{arg.name.colorize(:magenta)} arg of type #{arg.type.colorize(:magenta)} added to #{@name.colorize(:magenta)} method."
+    end
   end
 
   # Generate the args.

--- a/src/entities/module_info.cr
+++ b/src/entities/module_info.cr
@@ -10,11 +10,19 @@ class Cruml::Entities::ModuleInfo
   # Adds a method into module.
   def add_method(method : Cruml::Entities::MethodInfo) : Nil
     @methods << method
+
+    if Cruml::Renders::Config.verbose? == true
+      puts "VERBOSE : #{method.name.colorize(:magenta)} method to #{@name.colorize(:magenta)} module."
+    end
   end
 
   # Adds an instance var into module.
   def add_instance_var(name : String, type : String) : Nil
     @instance_vars.reject! { |ivar| ivar[0] == name }
     @instance_vars << {name, type}
+
+    if Cruml::Renders::Config.verbose? == true
+      puts "VERBOSE : #{name.colorize(:magenta)} instance var added to #{@name.colorize(:magenta)} module."
+    end
   end
 end

--- a/src/renders/config.cr
+++ b/src/renders/config.cr
@@ -6,6 +6,9 @@ class Cruml::Renders::Config
   # Whether to disable colors in the diagram.
   class_property? no_color : Bool = false
 
+  # Enable the verbose mode
+  class_property? verbose : Bool = false
+
   # Gets the color for classes.
   def self.class_color : String
     (@@theme == :light) ? "#baa7e5" : "#2e1065"


### PR DESCRIPTION
## Description

Set up information displays to show what has been done step by step.

### With `--verbose`

![image](https://github.com/user-attachments/assets/f6f158a2-2eae-4422-a2da-041c54a1dc89)

The object name and type are colored purple to make the information more visible.

![image](https://github.com/user-attachments/assets/f4146a89-f485-4f6b-91f0-c1a8085ad559)

In addition, statistics are displayed in tabular form, showing the number of Crystal files processed, the time it took to transform the code into Crystal, check instance variables and class variables and generate the Mermaid code.

### Without `--verbose`

![image](https://github.com/user-attachments/assets/0f7fc655-8b85-4502-8e70-24d78456fe18)

Only the success message will be displayed in green, along with the time it took to generate a class diagram.

## Changelog

- Setup the `--verbose` flag