### PR TITLE
Refactor classifiers

### DIFF
--- a/src/renders/classifier.cr
+++ b/src/renders/classifier.cr
@@ -2,7 +2,7 @@
 # namespaces into the class diagram.
 module Cruml::Renders::Classifier
   # Adds an object into the class diagram.
-  private def add_object(name : String, color : String) : Nil
+  private def add_object(name : String, color : String, &) : Nil
     @code << '"' << name << '"' << " {\n"
     @code << Cruml::Renders::UML::INDENT << "shape: class\n"
     unless Cruml::Renders::Config.no_color?

--- a/src/renders/classifier.cr
+++ b/src/renders/classifier.cr
@@ -1,4 +1,7 @@
+# Classifiers consists to add classes, abstract classes, interfaces, modules and
+# namespaces into the class diagram.
 module Cruml::Renders::Classifier
+  # Adds an object into the class diagram.
   private def add_object(name : String, color : String) : Nil
     @code << '"' << name << '"' << " {\n"
     @code << Cruml::Renders::UML::INDENT << "shape: class\n"
@@ -11,30 +14,35 @@ module Cruml::Renders::Classifier
     @code << "}\n"
   end
 
+  # Adds a normal class into the class diagram.
   private def add_normal_class(name : String, &) : Nil
     add_object(name, Cruml::Renders::Config.class_color) do
       yield
     end
   end
 
+  # Adds an abstract class into the class diagram.
   private def add_abstract_class(name : String, &) : Nil
     add_object(name, Cruml::Renders::Config.abstract_color) do
       yield
     end
   end
 
+  # Adds an interface into the class diagram.
   private def add_interface(name : String, &) : Nil
     add_object(name, Cruml::Renders::Config.interface_color) do
       yield
     end
   end
 
+  # Adds a namespace into the class diagram.
   private def add_namespace(name : String, &) : Nil
     @code << '"' << name << '"' << " {\n"
     yield
     @code << "}\n"
   end
 
+  # Adds a module into the class diagram.
   private def add_module(name : String, &)
     add_object(name, Cruml::Renders::Config.class_color) do
       yield

--- a/src/renders/classifier.cr
+++ b/src/renders/classifier.cr
@@ -1,38 +1,32 @@
 module Cruml::Renders::Classifier
-  private def add_normal_class(name : String, &) : Nil
+  private def add_object(name : String, color : String) : Nil
     @code << '"' << name << '"' << " {\n"
     @code << Cruml::Renders::UML::INDENT << "shape: class\n"
     unless Cruml::Renders::Config.no_color?
       @code << Cruml::Renders::UML::INDENT << <<-STR
-      style.fill: "#{Cruml::Renders::Config.class_color}"\n
+      style.fill: "#{color}"\n
       STR
     end
     yield
     @code << "}\n"
   end
 
-  private def add_abstract_class(name : String, &) : Nil
-    @code << Cruml::Renders::UML::INDENT << '"' << name << '"' << " {\n"
-    @code << Cruml::Renders::UML::INDENT << "shape: class\n"
-    unless Cruml::Renders::Config.no_color?
-      @code << Cruml::Renders::UML::INDENT << <<-STR
-      style.fill: "#{Cruml::Renders::Config.abstract_color}"\n
-      STR
+  private def add_normal_class(name : String, &) : Nil
+    add_object(name, Cruml::Renders::Config.class_color) do
+      yield
     end
-    yield
-    @code << Cruml::Renders::UML::INDENT << "}\n"
+  end
+
+  private def add_abstract_class(name : String, &) : Nil
+    add_object(name, Cruml::Renders::Config.abstract_color) do
+      yield
+    end
   end
 
   private def add_interface(name : String, &) : Nil
-    @code << Cruml::Renders::UML::INDENT << '"' << name << '"' << " {\n"
-    @code << Cruml::Renders::UML::INDENT * 2 << "shape: class\n"
-    unless Cruml::Renders::Config.no_color?
-      @code << Cruml::Renders::UML::INDENT << <<-STR
-      style.fill: "#{Cruml::Renders::Config.interface_color}"\n
-      STR
+    add_object(name, Cruml::Renders::Config.interface_color) do
+      yield
     end
-    yield
-    @code << Cruml::Renders::UML::INDENT << "}\n"
   end
 
   private def add_namespace(name : String, &) : Nil
@@ -42,9 +36,8 @@ module Cruml::Renders::Classifier
   end
 
   private def add_module(name : String, &)
-    @code << Cruml::Renders::UML::INDENT << '"' << name << '"' << " {\n"
-    @code << Cruml::Renders::UML::INDENT * 2 << "shape: class\n"
-    yield
-    @code << Cruml::Renders::UML::INDENT << "}\n"
+    add_object(name, Cruml::Renders::Config.class_color) do
+      yield
+    end
   end
 end


### PR DESCRIPTION
## Description

To avoid repetitions, `Cruml::Renders::Classifier#add_object` method is added and reused by other methods in that module.

## Changelog

- Refactor classifiers