### PR TITLE
Display args to protected and private methods.

### DIFF
--- a/examples/e11_links.cr
+++ b/examples/e11_links.cr
@@ -4,10 +4,12 @@ end
 
 class E11::G2::Sublink < E11::G1::Link
   protected def my_method : Void; end
+  protected def my_another_method_with_args(a : String, b : Int32) : Void; end
 end
 
 class E11::G3::SubSublink < E11::G2::Sublink
   private def my_another_method : Void; end
+  private def my_another_method_with_args(a : String, b : Int32) : Void; end
 end
 
 class E11::G3::AnotherSubSublink < E11::G2::Sublink

--- a/examples/e11_links.cr
+++ b/examples/e11_links.cr
@@ -4,11 +4,13 @@ end
 
 class E11::G2::Sublink < E11::G1::Link
   protected def my_method : Void; end
+
   protected def my_another_method_with_args(a : String, b : Int32) : Void; end
 end
 
 class E11::G3::SubSublink < E11::G2::Sublink
   private def my_another_method : Void; end
+
   private def my_another_method_with_args(a : String, b : Int32) : Void; end
 end
 

--- a/src/transformer.cr
+++ b/src/transformer.cr
@@ -209,7 +209,7 @@ class Cruml::Transformer < Crystal::Transformer
     if is_not_duplicated_method
       return_type = node.return_type.to_s || "Nil"
       visibility = node.name.to_s == "initialize" ? :protected : :public
-      method_name = node.receiver ? "self\.#{node.name}" : node.name
+      method_name = node.receiver ? "self.#{node.name}" : node.name
 
       method_info = Cruml::Entities::MethodInfo.new(visibility, method_name, return_type)
 


### PR DESCRIPTION
## Description

This bug concerns args that aren't displayed in protected and private methods. This PR corrects the problem.

## Changelog

Display args to protected and private methods.