### PR TITLE
Escape special characters to method name and args.

### DIFF
--- a/src/entities/method_info.cr
+++ b/src/entities/method_info.cr
@@ -12,7 +12,9 @@ class Cruml::Entities::MethodInfo
   # All arguments in a method.
   getter args = [] of Cruml::Entities::ArgInfo
 
-  def initialize(@visibility : Symbol, @name : String, @return_type : String); end
+  def initialize(@visibility : Symbol, @name : String, @return_type : String)
+    @name = escape_characters(@name)
+  end
 
   # Add an argument into the args list.
   def add_arg(arg : Cruml::Entities::ArgInfo)
@@ -23,22 +25,28 @@ class Cruml::Entities::MethodInfo
     end
   end
 
+  # Escape some special characters to avoid syntax errors during diagram
+  # compilation of d2.
+  private def escape_characters(input : String) : String
+    patterns = {
+      '|' => "\\|",
+      ':' => "\\:",
+      '.' => "\\.",
+      '{' => "\\{",
+      '}' => "\\}",
+      '<' => "\\<",
+      '[' => "\\[",
+      ']' => "\\]",
+    }
+
+    input.gsub(patterns)
+  end
+
   # Generate the args.
   def generate_args : String
     String.build do |str|
       @args.each_with_index do |arg, i|
-        patterns = {
-          '|' => "\\|",
-          ':' => "\\:",
-          '.' => "\\.",
-          '{' => "\\{",
-          '}' => "\\}",
-          '<' => "\\<",
-          '[' => "\\[",
-          ']' => "\\]",
-        }
-
-        str << "#{arg.name} \\: #{arg.type.gsub(patterns)}"
+        str << "#{arg.name} \\: #{escape_characters(arg.type)}"
         if i != @args.size - 1
           str << ", "
         end

--- a/src/transformer.cr
+++ b/src/transformer.cr
@@ -197,7 +197,7 @@ class Cruml::Transformer < Crystal::Transformer
     if is_not_duplicated_method
       return_type = node.return_type.to_s || "Nil"
       visibility = node.name.to_s == "initialize" ? :protected : :public
-      method_name = node.receiver ? "self\\.#{node.name}" : node.name
+      method_name = node.receiver ? "self.#{node.name}" : node.name
 
       method_info = Cruml::Entities::MethodInfo.new(visibility, method_name, return_type)
       add_args(node, method_info)


### PR DESCRIPTION
## Description

To prevent d2 from triggering syntax errors, some special characters are escaped thanks to backslashes.

## Changelog

- Escape special characters to method name and args.