### PR TITLE
Delete the postinstall system

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -20,12 +20,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 1.6.0
 
-scripts:
-  postinstall: shards build cruml
-
-executables:
-  - cruml
-
 crystal: '>= 1.16.0'
 
 license: MIT


### PR DESCRIPTION
## Description

As Cruml is a tool and not a library, the post-installation system is no longer used.

## Changelog

- Delete the postinstall system